### PR TITLE
Do not enclose some env values with double quotes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ initialize_system() {
   MAIL_PASSWORD=${MAIL_PASSWORD:-null}
   MAIL_ADDRESS=${MAIL_ADDRESS:-null}
   MAIL_NAME=${MAIL_NAME:-null}
-  MAIL_ENCRYPTION=${MAIL_ENCRYPTION:-none}
+  MAIL_ENCRYPTION=${MAIL_ENCRYPTION:-null}
 
   REDIS_HOST=${REDIS_HOST:-null}
   REDIS_DATABASE=${REDIS_DATABASE:-null}
@@ -86,16 +86,16 @@ initialize_system() {
   sed 's,{{MAIL_DRIVER}},'"${MAIL_DRIVER}"',g' -i /var/www/html/.env
   sed 's,{{MAIL_HOST}},'"${MAIL_HOST}"',g' -i /var/www/html/.env
   sed 's,{{MAIL_PORT}},'"${MAIL_PORT}"',g' -i /var/www/html/.env
-  sed 's,{{MAIL_USERNAME}},'"${MAIL_USERNAME}"',g' -i /var/www/html/.env
-  sed 's,{{MAIL_PASSWORD}},'"${MAIL_PASSWORD}"',g' -i /var/www/html/.env
-  sed 's,{{MAIL_ADDRESS}},'"${MAIL_ADDRESS}"',g' -i /var/www/html/.env
-  sed 's,{{MAIL_NAME}},'"${MAIL_NAME}"',g' -i /var/www/html/.env
-  sed 's,{{MAIL_ENCRYPTION}},'"${MAIL_ENCRYPTION}"',g' -i /var/www/html/.env
+  sed 's,{{MAIL_USERNAME}},'${MAIL_USERNAME}',g' -i /var/www/html/.env
+  sed 's,{{MAIL_PASSWORD}},'${MAIL_PASSWORD}',g' -i /var/www/html/.env
+  sed 's,{{MAIL_ADDRESS}},'${MAIL_ADDRESS}',g' -i /var/www/html/.env
+  sed 's,{{MAIL_NAME}},'${MAIL_NAME}',g' -i /var/www/html/.env
+  sed 's,{{MAIL_ENCRYPTION}},'${MAIL_ENCRYPTION}',g' -i /var/www/html/.env
 
-  sed 's,{{REDIS_HOST}},'"${REDIS_HOST}"',g' -i /var/www/html/.env
-  sed 's,{{REDIS_DATABASE}},'"${REDIS_DATABASE}"',g' -i /var/www/html/.env
-  sed 's,{{REDIS_PORT}},'"${REDIS_PORT}"',g' -i /var/www/html/.env
-  sed 's,{{REDIS_PASSWORD}},'"${REDIS_PASSWORD}"',g' -i /var/www/html/.env
+  sed 's,{{REDIS_HOST}},'${REDIS_HOST}',g' -i /var/www/html/.env
+  sed 's,{{REDIS_DATABASE}},'${REDIS_DATABASE}',g' -i /var/www/html/.env
+  sed 's,{{REDIS_PORT}},'${REDIS_PORT}',g' -i /var/www/html/.env
+  sed 's,{{REDIS_PASSWORD}},'${REDIS_PASSWORD}',g' -i /var/www/html/.env
   
   sed 's,{{GITHUB_TOKEN}},'"${GITHUB_TOKEN}"',g' -i /var/www/html/.env
 


### PR DESCRIPTION
This was making some configuration ending with something like MAIL_USERNAME="null", instead of MAIL_USERNAME=null